### PR TITLE
Update to azure-pipelines-dotnet:6.0.302.1 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swissgrc/azure-pipelines-dotnet:6.0.302
+FROM swissgrc/azure-pipelines-dotnet:6.0.302.1
 
 LABEL org.opencontainers.image.vendor="Swiss GRC AG"
 LABEL org.opencontainers.image.authors="Swiss GRC AG <opensource@swissgrc.com>"


### PR DESCRIPTION
Update to azure-pipelines-dotnet:6.0.302.1 base image which fixes Curl CVEs